### PR TITLE
Removed implicit conversion: 'int64_t'>'uint64_t'

### DIFF
--- a/broadword.hpp
+++ b/broadword.hpp
@@ -169,7 +169,7 @@ namespace succinct { namespace broadword {
         if (!x) {
             return false;
         }
-        ret = bit_position(x & -int64_t(x));
+        ret = bit_position(x & -x);
         return true;
 #endif
     }


### PR DESCRIPTION
Compiling with Apple LLVM version 8.1.0 I get the following error
```bash
warning: implicit conversion changes signedness: 'int64_t' (aka 'long long') to 'unsigned long long'
```