### PR TITLE
optimize select_in_word

### DIFF
--- a/broadword.hpp
+++ b/broadword.hpp
@@ -89,13 +89,13 @@ namespace succinct { namespace broadword {
 
         uint64_t byte_sums = byte_counts(x) * ones_step_8;
 
-        const uint64_t k_step_8 = k * ones_step_8;
-        const uint64_t geq_k_step_8 = (((k_step_8 | msbs_step_8) - byte_sums) & msbs_step_8);
-#if SUCCINCT_USE_POPCNT
-        const uint64_t place = intrinsics::popcount(geq_k_step_8) * 8;
-#else
-        const uint64_t place = ((geq_k_step_8 >> 7) * ones_step_8 >> 53) & ~uint64_t(0x7);
-#endif
+        const uint64_t k_step_8 = (k | 0x80) * ones_step_8;
+        const uint64_t geq_k_step_8 = k_step_8 - byte_sums;
+    #if SUCCINCT_USE_POPCNT
+        const uint64_t place = intrinsics::popcount(geq_k_step_8 & msbs_step_8) * 8;
+    #else
+        const uint64_t place = (((geq_k_step_8 >> 7) & ones_step_8) * ones_step_8 >> 53);
+    #endif
         const uint64_t byte_rank = k - (((byte_sums << 8 ) >> place) & uint64_t(0xFF));
         return place + tables::select_in_byte[((x >> place) & 0xFF ) | (byte_rank << 8)];
     }

--- a/broadword.hpp
+++ b/broadword.hpp
@@ -91,11 +91,11 @@ namespace succinct { namespace broadword {
 
         const uint64_t k_step_8 = (k | 0x80) * ones_step_8;
         const uint64_t geq_k_step_8 = k_step_8 - byte_sums;
-    #if SUCCINCT_USE_POPCNT
+#if SUCCINCT_USE_POPCNT
         const uint64_t place = intrinsics::popcount(geq_k_step_8 & msbs_step_8) * 8;
-    #else
+#else
         const uint64_t place = (((geq_k_step_8 >> 7) & ones_step_8) * ones_step_8 >> 53);
-    #endif
+#endif
         const uint64_t byte_rank = k - (((byte_sums << 8 ) >> place) & uint64_t(0xFF));
         return place + tables::select_in_byte[((x >> place) & 0xFF ) | (byte_rank << 8)];
     }


### PR DESCRIPTION
Today I decided to reinvent this algorithm. Then I remembered this project, and decided to see if this repository had a better idea.

Turns out, my version had a few slight improvements over the implementation here.

1. We can do `(k | 0x80) * ones_step_8` rather than `(k * ones_step_8) | msbs_step_8`. This is helpful because we want to avoid loading `msbs_step_8` when not using the popcount implementation.
2. We do not need ` & ~uint64_t(0x7)`. This is easy to prove, since the maximum value it can operate on is `00001000_00000111_00000110_00000101_00000100_00000011_00000010_00000001`. Since the byte under the most significant byte can be a 7 at most, the upper 3 bits of that second byte are always 0. Therefore we do not need to zero them out.
3. Rather than doing `(x & msbs_step_8) >> 7` we can do `(x >> 7) & ones_step_8`, which means we do not have to load `msbs_step_8`.
